### PR TITLE
Add Makerere University Business School

### DIFF
--- a/lib/domains/ac/ug/mubs/mubs.txt
+++ b/lib/domains/ac/ug/mubs/mubs.txt
@@ -1,0 +1,1 @@
+Makerere University Business school


### PR DESCRIPTION
This pull request adds Makerere University Business School to the JetBrains educational license list using the domain mubs.ac.ug.